### PR TITLE
Fix installation reference in index.rst

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,7 @@ It pulls data from the `Open Food Facts database <https://world.openfoodfacts.or
 and offers a *simple* and *intuitive* API.
 
 Check out the :doc:`usage` section for further information, including
-how to :ref:`installation` the project.
+how to :ref:`install <installation>` the project.
 
 .. note::
 


### PR DESCRIPTION
In [docs/index.rst](https://github.com/readthedocs-examples/example-sphinx-basic/blob/10dfba1761190af60d168b9102c40182d62280f2/docs/index.rst?plain=1#L12), an unaliased reference to the installation label is used, causing the surrounding sentence to [render](https://example-sphinx-basic.readthedocs.io/en/stable/) as the following:

```text
Check out the Usage section for further information, including how to Installation the project.
```

The word Installation is incorrect given the context. Using the following syntax fixes this:

```rst
:ref:`install <installation>`
```